### PR TITLE
Add arm64 to docker manifest

### DIFF
--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -111,4 +111,5 @@ publish_docker_manifest () {
 }
 
 publish_docker_images_with_arch_suffix focal amd64
-publish_docker_manifest focal amd64
+publish_docker_images_with_arch_suffix focal arm64
+publish_docker_manifest focal amd64 arm64


### PR DESCRIPTION
I think this is all that's needed to publish the dotnet container for arm64 builds